### PR TITLE
fix the bug in displaying more than 4 images

### DIFF
--- a/client/src/components/slider/Slider.jsx
+++ b/client/src/components/slider/Slider.jsx
@@ -38,17 +38,19 @@ function Slider({ images }) {
           </div>
         </div>
       )}
-      <div className="bigImage">
+     <div className="bigImage">
         <img src={images[0]} alt="" onClick={() => setImageIndex(0)} />
       </div>
       <div className="smallImages">
-        {images.slice(1).map((image, index) => (
-          <img
-            src={image}
-            alt=""
+        {images.slice(1, 4).map((image, index) => (
+          <div
+            className={`imageContainer ${index+1 === 3 ? "blur" : ""}`}
             key={index}
-            onClick={() => setImageIndex(index + 1)}
-          />
+          > 
+            {index+1 === 3 && <div className="blurOverlay"onClick={() => setImageIndex(3)}></div>}
+            <img src={image} alt="" onClick={() => setImageIndex(index + 1)} />
+            {index+1 === 3 && <span>+{images.length - 3}</span>}
+          </div>
         ))}
       </div>
     </div>

--- a/client/src/components/slider/slider.scss
+++ b/client/src/components/slider/slider.scss
@@ -99,5 +99,48 @@
         height: 80px;
       }
     }
+    .imageContainer {
+      position: relative;
+      width: 100%;
+      height: 100%;
+
+      img {
+        height: 100px;
+        object-fit: cover;
+        border-radius: 10px;
+        cursor: pointer;
+
+        @include sm {
+          height: 80px;
+        }
+      }
+
+      .blurOverlay {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        background-color: rgba(0, 0, 0, 0.5);
+        backdrop-filter: blur(5px);
+        z-index: 1;
+        border-radius: 10px;
+        cursor: pointer;
+      }
+
+      span {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        color: white;
+        font-weight: bold;
+        z-index: 2;
+      }
+
+      &.blur {
+        img {
+          opacity: 1;
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
In the event that the user uploads more than five images, the slider will show just three messages, blur the fourth image, and overlay that image with +2.