### PR TITLE
fixed user creation bug

### DIFF
--- a/api/controllers/auth.controller.js
+++ b/api/controllers/auth.controller.js
@@ -6,6 +6,19 @@ export const register = async (req, res) => {
   const { username, email, password } = req.body;
 
   try {
+
+    const existingUser = await prisma.user.findFirst({
+      where: {
+        OR: [
+          { username: username },
+          { email: email }
+        ]
+      }
+    });
+
+    if (existingUser) {
+      return res.status(400).json({ message: 'Username or email already exists' });
+    }
     // HASH THE PASSWORD
 
     const hashedPassword = await bcrypt.hash(password, 10);


### PR DESCRIPTION
While registering, if you input an already existing username or password, the app will cease to take any new users. Fixed the code to gracefully handle the error